### PR TITLE
Fix node-gyp read-only property error in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bootstrap": "^4.4.1",
     "fs": "^0.0.1-security",
     "linq-to-typescript": "^9.0.0",
-    "node-sass": "^6.0.1",
+    "sass": "^1.58.0",
     "overlayscrollbars": "^1.13.1",
     "overlayscrollbars-react": "^0.2.3",
     "react": "^16.12.0",


### PR DESCRIPTION
Replaced deprecated node-sass (v6.0.1) with sass (v1.58.0) to resolve node-gyp compatibility issues with Node.js v20. The sass package (dart-sass) is the official replacement for node-sass and works as a drop-in replacement.

This fixes the error:
"TypeError: Cannot assign to read only property 'cflags' of object"

The new sass package:
- Is actively maintained
- Works with all Node.js versions including v20+
- Provides better performance and standards compliance
- Requires no code changes for existing SCSS files